### PR TITLE
Release changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 # Build output
 bin/
+pkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## UNRELEASED
+
+* Initial realse of standalone Nomad Nvidia device plugin.

--- a/device.go
+++ b/device.go
@@ -1,4 +1,4 @@
-package nvidia
+package main
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-device-nvidia/version"
 	"github.com/hashicorp/nomad/devices/gpu/nvidia/nvml"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/plugins/base"
@@ -51,7 +52,7 @@ var (
 	pluginInfo = &base.PluginInfoResponse{
 		Type:              base.PluginTypeDevice,
 		PluginApiVersions: []string{device.ApiVersion010},
-		PluginVersion:     "0.1.0",
+		PluginVersion:     version.Version,
 		Name:              pluginName,
 	}
 

--- a/device_test.go
+++ b/device_test.go
@@ -1,4 +1,4 @@
-package nvidia
+package main
 
 import (
 	"testing"

--- a/fingerprint.go
+++ b/fingerprint.go
@@ -1,4 +1,4 @@
-package nvidia
+package main
 
 import (
 	"context"

--- a/fingerprint_test.go
+++ b/fingerprint_test.go
@@ -1,4 +1,4 @@
-package nvidia
+package main
 
 import (
 	"context"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/nomad-device-nvidia
 go 1.16
 
 require (
-	github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20210525204842-7fbe8db26700
+	github.com/NVIDIA/go-nvml v0.11.1-0
 	github.com/hashicorp/go-hclog v0.16.1
 	github.com/hashicorp/nomad v1.1.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -47,7 +47,6 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/LK4D4/joincontext v0.0.0-20171026170139-1724345da6d5 h1:U7q69tqXiCf6m097GRlNQB0/6SI1qWIOHYHhCEvDxF4=
 github.com/LK4D4/joincontext v0.0.0-20171026170139-1724345da6d5/go.mod h1:nxQPcNPR/34g+HcK2hEsF99O+GJgIkW/OmPl8wtzhmk=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.3/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/go-winio v0.4.15-0.20200113171025-3fe6c5262873 h1:93nQ7k53GjoMQ07HVP8g6Zj1fQZDDj7Xy2VkNNtvX8o=
@@ -55,10 +54,10 @@ github.com/Microsoft/go-winio v0.4.15-0.20200113171025-3fe6c5262873/go.mod h1:tT
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/Microsoft/hcsshim v0.8.8-0.20200312192636-fd0797d766b1 h1:2T9t72RkTRjAcuFc+4vaGWnRx/anVngE1/VGN/HFEVk=
 github.com/Microsoft/hcsshim v0.8.8-0.20200312192636-fd0797d766b1/go.mod h1:LVvUcNYEzt59fFVTuiPEgM6dgF70yMGdy/Qc/UmCbuU=
+github.com/NVIDIA/go-nvml v0.11.1-0 h1:XHSz3zZKC4NCP2ja1rI7++DXFhA+uDhdYa3MykCTGHY=
+github.com/NVIDIA/go-nvml v0.11.1-0/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=
+github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20180829222009-86f2a9fac6c5 h1:WLyvLAM0QfjAarRzRTG9EgT5McqGWNZMvqqSUSoyUUY=
 github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20180829222009-86f2a9fac6c5/go.mod h1:nMOvShGpWaf0bXwXmeu4k+O4uziuaEI8pWzIj3BUrOA=
-github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20210525204842-7fbe8db26700 h1:1FxK6qecUUD+XAcaTIrRwhl67gDoB3IAfkuWnaqwk5o=
-github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20210525204842-7fbe8db26700/go.mod h1:oKPJa5eOTkWvlT4/Y4D8Nds44Fzmww5HUK+xwO+DwTA=
-github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm v0.0.0-20210325210537-29b4f1784f18/go.mod h1:8qXwltEzU3idjUcVpMOv3FNgxxbDeXZPGMLyc/khWiY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/plugins"
+)
+
+func main() {
+	// Serve the plugin
+	plugins.Serve(factory)
+}
+
+// factory returns a new instance of the LXC driver plugin
+func factory(log log.Logger) interface{} {
+	return NewNvidiaDevice(context.Background(), log)
+}

--- a/nvml/driver_linux.go
+++ b/nvml/driver_linux.go
@@ -1,7 +1,7 @@
 package nvml
 
 import (
-	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
 // Initialize nvml library by locating nvml shared object file and calling ldopen

--- a/stats.go
+++ b/stats.go
@@ -1,4 +1,4 @@
-package nvidia
+package main
 
 import (
 	"context"

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,4 +1,4 @@
-package nvidia
+package main
 
 import (
 	"errors"

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,50 @@
+package version
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	// The git commit that was compiled. These will be filled in by the compiler.
+	GitCommit   string
+	GitDescribe string
+
+	// The main version number that is being run at the moment.
+	//
+	// Version must conform to the format expected by
+	// github.com/hashicorp/go-version for tests to work.
+	Version = "1.0.0"
+
+	// A pre-release marker for the version. If this is "" (empty string)
+	// then it means that it is a final release. Otherwise, this is a pre-release
+	// such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease = ""
+)
+
+// GetHumanVersion composes the parts of the version in a way that's suitable
+// for displaying to humans.
+func GetHumanVersion() string {
+	version := Version
+	if GitDescribe != "" {
+		version = GitDescribe
+	}
+
+	release := VersionPrerelease
+	if GitDescribe == "" && release == "" {
+		release = "dev"
+	}
+
+	if release != "" {
+		if !strings.HasSuffix(version, "-"+release) {
+			// if we tagged a prerelease version then the release is in the version already
+			version += fmt.Sprintf("-%s", release)
+		}
+		if GitCommit != "" {
+			version += fmt.Sprintf(" (%s)", GitCommit)
+		}
+	}
+
+	// Strip off any single quotes added by the git information.
+	return strings.Replace(version, "'", "", -1)
+}


### PR DESCRIPTION
This PR add changes required by the release pipeline:

- Add `CHANGELOG.md`
- `gitignore` the `pkg` directory
- Create `main.go`
- Fix `package` in the Go files at the root level
- Create `version/vergion.go` file
- Update `nvml` dependency because `gpu-monitoring-tools` has been [deprecated](https://github.com/NVIDIA/gpu-monitoring-tools#final-update-august-2021---this-repository-has-been-deprecated)