### PR TITLE
Add rudimentary support for MIG devices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/NVIDIA/go-nvml v0.11.1-0
+	github.com/NVIDIA/go-nvml v0.12.0-1.0.20231020145430-e06766c5e74f
 	github.com/hashicorp/go-hclog v1.2.0
 	github.com/hashicorp/nomad v1.3.1
 	github.com/shoenig/test v0.2.5
@@ -90,7 +90,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.21.12 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
@@ -110,5 +110,5 @@ require (
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/Microsoft/hcsshim v0.8.23 h1:47MSwtKGXet80aIn+7h4YI6fwPmwIghAnsx2aOUr
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/NVIDIA/go-nvml v0.11.1-0 h1:XHSz3zZKC4NCP2ja1rI7++DXFhA+uDhdYa3MykCTGHY=
 github.com/NVIDIA/go-nvml v0.11.1-0/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=
+github.com/NVIDIA/go-nvml v0.12.0-1.0.20231020145430-e06766c5e74f h1:FTblgO87K1vPB8tcwM5EOFpFf6UpsrlDpErPm25mFWE=
+github.com/NVIDIA/go-nvml v0.12.0-1.0.20231020145430-e06766c5e74f/go.mod h1:7ruy85eOM73muOc/I37euONSwEyFqZsv5ED9AogD4G0=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -457,6 +459,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -465,6 +470,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=

--- a/nvml/client.go
+++ b/nvml/client.go
@@ -103,17 +103,17 @@ func (c *nvmlClient) GetFingerprintData() (*FingerprintData, error) {
 		return nil, fmt.Errorf("nvidia nvml SystemDriverVersion() error: %v\n", err)
 	}
 
-	numDevices, err := c.driver.DeviceCount()
+	deviceUUIDs, err := c.driver.ListDeviceUUIDs()
 	if err != nil {
-		return nil, fmt.Errorf("nvidia nvml DeviceCount() error: %v\n", err)
+		return nil, fmt.Errorf("nvidia nvml ListDeviceUUIDs() error: %v\n", err)
 	}
 
-	allNvidiaGPUResources := make([]*FingerprintDeviceData, numDevices)
+	allNvidiaGPUResources := make([]*FingerprintDeviceData, len(deviceUUIDs))
 
-	for i := 0; i < int(numDevices); i++ {
-		deviceInfo, err := c.driver.DeviceInfoByIndex(uint(i))
+	for i, element := range deviceUUIDs {
+		deviceInfo, err := c.driver.DeviceInfoByUUID(element)
 		if err != nil {
-			return nil, fmt.Errorf("nvidia nvml DeviceInfoByIndex() error: %v\n", err)
+			return nil, fmt.Errorf("nvidia nvml DeviceInfoByUUID() error: %v\n", err)
 		}
 
 		allNvidiaGPUResources[i] = &FingerprintDeviceData{
@@ -159,17 +159,17 @@ func (c *nvmlClient) GetStatsData() ([]*StatsData, error) {
 	// NewNvmlClient
 	// because this method handles initialization of NVML library
 
-	numDevices, err := c.driver.DeviceCount()
+	deviceUUIDs, err := c.driver.ListDeviceUUIDs()
 	if err != nil {
-		return nil, fmt.Errorf("nvidia nvml DeviceCount() error: %v\n", err)
+		return nil, fmt.Errorf("nvidia nvml ListDeviceUUIDs() error: %v\n", err)
 	}
 
-	allNvidiaGPUStats := make([]*StatsData, numDevices)
+	allNvidiaGPUStats := make([]*StatsData, len(deviceUUIDs))
 
-	for i := 0; i < int(numDevices); i++ {
-		deviceInfo, deviceStatus, err := c.driver.DeviceInfoAndStatusByIndex(uint(i))
+	for i, element := range deviceUUIDs {
+		deviceInfo, deviceStatus, err := c.driver.DeviceInfoAndStatusByUUID(element)
 		if err != nil {
-			return nil, fmt.Errorf("nvidia nvml DeviceInfoAndStatusByIndex() error: %v\n", err)
+			return nil, fmt.Errorf("nvidia nvml DeviceInfoAndStatusByUUID() error: %v\n", err)
 		}
 
 		allNvidiaGPUStats[i] = &StatsData{

--- a/nvml/driver_default.go
+++ b/nvml/driver_default.go
@@ -20,17 +20,17 @@ func (n *nvmlDriver) SystemDriverVersion() (string, error) {
 	return "", UnavailableLib
 }
 
-// DeviceCount reports number of available GPU devices
-func (n *nvmlDriver) DeviceCount() (uint, error) {
+// ListDeviceUUIDs reports number of available GPU devices
+func (n *nvmlDriver) ListDeviceUUIDs() ([]string, error) {
 	return 0, UnavailableLib
 }
 
-// DeviceInfoByIndex returns DeviceInfo for index GPU in system device list
-func (n *nvmlDriver) DeviceInfoByIndex(index uint) (*DeviceInfo, error) {
+// DeviceInfoByUUID returns DeviceInfo for the GPU matching the given UUID
+func (n *nvmlDriver) DeviceInfoByUUID(uuid string) (*DeviceInfo, error) {
 	return nil, UnavailableLib
 }
 
-// DeviceInfoByIndex returns DeviceInfo and DeviceStatus for index GPU in system device list
-func (n *nvmlDriver) DeviceInfoAndStatusByIndex(index uint) (*DeviceInfo, *DeviceStatus, error) {
+// DeviceInfoAndStatusByUUID returns DeviceInfo and DeviceStatus for the GPU matching the given UUID
+func (n *nvmlDriver) DeviceInfoAndStatusByUUID(uuid string) (*DeviceInfo, *DeviceStatus, error) {
 	return nil, nil, UnavailableLib
 }

--- a/nvml/shared.go
+++ b/nvml/shared.go
@@ -19,14 +19,14 @@ type NvmlDriver interface {
 	Initialize() error
 	Shutdown() error
 	SystemDriverVersion() (string, error)
-	DeviceCount() (uint, error)
-	DeviceInfoByIndex(uint) (*DeviceInfo, error)
-	DeviceInfoAndStatusByIndex(uint) (*DeviceInfo, *DeviceStatus, error)
+	ListDeviceUUIDs() ([]string, error)
+	DeviceInfoByUUID(string) (*DeviceInfo, error)
+	DeviceInfoAndStatusByUUID(string) (*DeviceInfo, *DeviceStatus, error)
 }
 
 // DeviceInfo represents nvml device data
-// this struct is returned by NvmlDriver DeviceInfoByIndex and
-// DeviceInfoAndStatusByIndex methods
+// this struct is returned by NvmlDriver DeviceInfoByUUID and
+// DeviceInfoAndStatusByUUID methods
 type DeviceInfo struct {
 	// The following fields are guaranteed to be retrieved from nvml
 	UUID            string
@@ -46,7 +46,7 @@ type DeviceInfo struct {
 }
 
 // DeviceStatus represents nvml device status
-// this struct is returned by NvmlDriver DeviceInfoAndStatusByIndex method
+// this struct is returned by NvmlDriver DeviceInfoAndStatusByUUID method
 type DeviceStatus struct {
 	// The following fields can be nil after call to nvml, because nvml was
 	// not able to retrieve this fields for specific nvidia card


### PR DESCRIPTION
This PR introduces basic support for MIG devices, and refactors the internal client to treat any GPU unit with a UUID as a new resource rather than indexed cuda device IDs (which are physical accelerators). We are still experimenting with it internally but pre-PR feedback is always appreciated since we also want to upstream it. Related to #3.

MIG devices are listed with their parent device name + MIG name (https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#device-names). Workloads can be scheduled with using those. 

Some of the fingerprinted properties come from the underlying device (e.g. PCIE bus id or total PCIE bandwith), but the important compute factors such as the memory a device has directly comes from the MIG slice.

```json
"Devices": [
    {
        "Vendor": "nvidia",
        "Type": "gpu",
        "Name": "NVIDIA A100-SXM4-40GB MIG 3g.20gb",
        "Instances": [
            {
                "ID": "MIG-ef272c5a-6ffd-5813-904c-ae1325994ab0",
                "Healthy": true,
                "HealthDescription": "",
                "Locality": {
                    "PciBusID": "00000000:06:00.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
                }
            },
            {
                "ID": "MIG-9624b115-48ad-51e3-b1d6-d7a9f488704e",
                "Healthy": true,
                "HealthDescription": "",
                "Locality": {
                    "PciBusID": "00000000:06:00.0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
                }
            }
        ],
        "Attributes": {
            "pci_bandwidth": {
                "Int": 32768,
                "Unit": "MB/s"
            },
            "bar1": {
                "Int": 65536,
                "Unit": "MiB"
            },
            "persistence_mode": {
                "String": "1",
            },
            "memory": {
                "Int": 19968,
                "Unit": "MiB"
            },
            "cores_clock": {
                "Int": 600,
                "Unit": "MHz"
            },
            "display_state": {
                "Bool": null,
                "Float": null,
                "Int": null,
                "String": "1",
                "Unit": ""
            },
            "power": {
                "Int": 46,
                "Unit": "W"
            },
            "driver_version": {
                "String": "535.104.12",
                "Unit": ""
            },
            "memory_clock": {
                "Int": 1215,
                "Unit": "MHz"
            }
        }
    }
],
```

Executing workloads using nvidia-docker runtime on a MIG device seems to work pretty well, and only a single partition is displayed when the underlying container calls `nvidia-smi` which is the expected behavior.