### PR TITLE
ci: update build.yaml for CRT builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,6 @@
 name: build
 
-on:
-  push:
-  workflow_dispatch:
+on: [workflow_dispatch, push]
 
 env:
   PKG_NAME: "nomad-device-nvidia"
@@ -10,37 +8,37 @@ env:
 jobs:
   get-go-version:
     name: "Determine Go toolchain version"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Determine Go version
         id: get-go-version
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
+          echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
   get-product-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: get product version
         id: get-product-version
         run: |
           make version
-          echo "product-version=$(make version)" >> $GITHUB_OUTPUT
+          echo "product-version=$(make version)" >> "$GITHUB_OUTPUT"
 
   generate-metadata-file:
     needs: get-product-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: "Checkout directory"
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -48,7 +46,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         if: ${{ !env.ACT }}
         with:
           name: metadata.json
@@ -58,32 +56,54 @@ jobs:
     needs:
       - get-go-version
       - get-product-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         goos: ["linux"]
         goarch: ["amd64"]
       fail-fast: true
-
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Setup go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-        with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: hashicorp/setup-golang@v3
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          make dist/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv \
-            pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip \
+            dist/${{ matrix.goos }}_${{ matrix.goarch }}.zip \
             ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         if: ${{ !env.ACT }}
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+      - name: Package
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/actions-packaging-linux@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "nomad-device-nvidia is a HashiCorp Nomad device driver for Linux."
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/nomad-device-nvidia"
+          license: "MPL-2.0"
+          binary: "dist/${{ matrix.goos }}_${{ matrix.goarch }}/${{ env.PKG_NAME }}"
+      - name: Set Package Names
+        if: ${{ matrix.goos == 'linux' }}
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> "$GITHUB_ENV"
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> "$GITHUB_ENV"
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}

--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,15 @@ hack:
 	sudo nomad agent -dev -plugin-dir=$(NOMAD_PLUGIN_DIR)
 
 # CRT release compilation
-pkg/%/nomad-device-nvidia: GO_OUT ?= $@
-pkg/%/nomad-device-nvidia:
+dist/%/nomad-device-nvidia: GO_OUT ?= $@
+dist/%/nomad-device-nvidia:
 	@echo "==> RELEASE BUILD of $@ ..."
 	GOOS=linux GOARCH=$(lastword $(subst _, ,$*)) \
 	go build -trimpath -o $(GO_OUT) cmd/main.go
 
 # CRT release packaging (zip only)
-.PRECIOUS: pkg/%/nomad-device-nvidia
-pkg/%.zip: pkg/%/nomad-device-nvidia
+.PRECIOUS: dist/%/nomad-device-nvidia
+dist/%.zip: dist/%/nomad-device-nvidia
 	@echo "==> RELEASE PACKAGING of $@ ..."
 	@cp LICENSE $(dir $<)LICENSE.txt
 	zip -j $@ $(dir $<)*


### PR DESCRIPTION
Includes now generating linux package (only for linux/amd64).
