### PR TITLE
Fix for type mismatch in nvml/driver_default.go

### DIFF
--- a/nvml/driver_default.go
+++ b/nvml/driver_default.go
@@ -21,7 +21,7 @@ func (n *nvmlDriver) SystemDriverVersion() (string, error) {
 }
 
 // ListDeviceUUIDs reports number of available GPU devices
-func (n *nvmlDriver) ListDeviceUUIDs() ([]string, error) {
+func (n *nvmlDriver) ListDeviceUUIDs() (map[string]mode, error) {
 	return nil, UnavailableLib
 }
 


### PR DESCRIPTION
Fix for type mismatch in nvml/driver_default.go:
```
../../go/pkg/mod/github.com/hashicorp/nomad-device-nvidia@v1.0.1-0.20241001184652-ded723023fae/nvml/client.go:78:11: cannot use driver (variable of type *nvmlDriver) as NvmlDriver value in struct literal: *nvmlDriver does not implement NvmlDriver (wrong type for method ListDeviceUUIDs)
		have ListDeviceUUIDs() ([]string, error)
		want ListDeviceUUIDs() (map[string]mode, error)
```