### PR TITLE
Allow for bar1 retrieval to be optional by handling NOT_SUPPORTED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
+ * driver: Added support for GPUs with unified memory/no dedicated BAR1 memory (such as GH200s, GB10s, etc) [[GH-87](https://github.com/hashicorp/nomad-device-nvidia/pull/87)]
  * build: Updated Nomad to 1.11.0 [[GH-80](https://github.com/hashicorp/nomad-device-nvidia/pull/80)]
  * build: Updated to Go 1.25.5 [[GH-82](https://github.com/hashicorp/nomad-device-nvidia/pull/82)]
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This adds support for GH200s, systems like the Spark DGX, etc which do not report/have BAR1 memory/have unified memory:

```
chris@spark-dc21:~$ nvidia-smi -q

==============NVSMI LOG==============

Timestamp                                 : Mon Jan 19 01:12:47 2026
Driver Version                            : 580.95.05
CUDA Version                              : 13.0

Attached GPUs                             : 1
GPU 0000000F:01:00.0
    Product Name                          : NVIDIA GB10
    Product Brand                         : NVIDIA RTX
..
    BAR1 Memory Usage
        Total                             : N/A
        Used                              : N/A
```

```
GPU 00000000:DD:00.0
    Product Name                          : NVIDIA GH200 480GB
    Product Brand                         : NVIDIA
    Product Architecture                  : Hopper
...
    BAR1 Memory Usage
        Total                             : N/A
        Used                              : N/A
        Free                              : N/A
```

With this change Nomad will report N/A:

```
Device Stats
Device              = nvidia/gpu/NVIDIA GH200 480GB[GPU-d8831f06-82ba-317d-a482-0ce4d49650ba]
BAR1 buffer state   = N/A
Decoder utilization = 0 %
ECC L1 errors       = 0 #
ECC L2 errors       = 0 #
ECC memory errors   = 0 #
Encoder utilization = 0 %
GPU utilization     = 0 %
Memory state        = 87711 / 97871 MiB
Memory utilization  = 0 %
Power usage         = 151571 / 151 W
Temperature         = 39 C
```