### PR TITLE
Fix GPU power usage units

### DIFF
--- a/nvml/driver_linux.go
+++ b/nvml/driver_linux.go
@@ -358,7 +358,7 @@ func (n *nvmlDriver) DeviceInfoAndStatusByUUID(uuid string) (*DeviceInfo, *Devic
 				return nil, nil, decode("failed to get device power usage", code)
 			}
 		}
-		powerU = uint(power)
+		powerU = uint(power) / 1000
 	}
 
 	ecc, code := nvml.DeviceGetDetailedEccErrors(device, nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC)


### PR DESCRIPTION
[NVML](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html) returns milliwatts, but the plugin labels them as watts. The same problem appears with different hardware too: [GH200](https://github.com/hashicorp/nomad-device-nvidia/pull/86#issuecomment-3776466582).

Divide by 1000 so `4034 mW` becomes `4 W`. This keep the existing integer fields. Unsupported readings still report `0 W` (that might need a separate fix or its ok, idk).

Tests: `go test -race ./...` and `go vet ./...` pass.